### PR TITLE
Add keyboard shortcuts for invoice modal

### DIFF
--- a/pdv.blade.php
+++ b/pdv.blade.php
@@ -560,8 +560,8 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" id="btnNaoEmitirNFe" data-bs-dismiss="modal">Não</button>
-          <button type="button" class="btn btn-primary" id="btnConfirmarEmitirNFe">Emitir NF-e</button>
-          <button type="button" class="btn btn-primary" id="btnConfirmarEmitirNFCE">Emitir NFC-e</button>
+          <button type="button" class="btn btn-primary" id="btnConfirmarEmitirNFe">Emitir NF-e (1)</button>
+          <button type="button" class="btn btn-primary" id="btnConfirmarEmitirNFCE">Emitir NFC-e (2)</button>
         </div>
       </div>
     </div>
@@ -1616,22 +1616,32 @@
           });
 
 
-          modalNFeEl.addEventListener('hidden.bs.modal', () => {
-            console.log('DEBUG abrirModalConfirmarNFe: removendo second-backdrop');
-            document.querySelectorAll('.modal-backdrop.second-backdrop').forEach(el => el.remove());
-          });
-
-          modalNFeEl.addEventListener('keydown', function(e) {
+          const handleModalKeydown = function(e) {
             if (e.key === 'Escape') {
               e.preventDefault();
               document.getElementById('btnNaoEmitirNFe').click();
             }
             if (e.key === 'Enter') {
               e.preventDefault();
-              const modalNFeEl = document.getElementById('modalConfirmarNFe');
               bootstrap.Modal.getInstance(modalNFeEl).hide();
               document.getElementById('btnConfirmarEmitirNFe').click();
             }
+            if (e.key === '1') {
+              e.preventDefault();
+              document.getElementById('btnConfirmarEmitirNFe').click();
+            }
+            if (e.key === '2') {
+              e.preventDefault();
+              document.getElementById('btnConfirmarEmitirNFCE').click();
+            }
+          };
+
+          modalNFeEl.addEventListener('keydown', handleModalKeydown);
+
+          modalNFeEl.addEventListener('hidden.bs.modal', () => {
+            console.log('DEBUG abrirModalConfirmarNFe: removendo second-backdrop');
+            document.querySelectorAll('.modal-backdrop.second-backdrop').forEach(el => el.remove());
+            modalNFeEl.removeEventListener('keydown', handleModalKeydown);
           });
         }
 


### PR DESCRIPTION
## Summary
- add keyboard hints to emit note buttons
- enable keys `1` and `2` to trigger NF-e and NFC-e emission when the modal is open
- clean up key listener when the modal closes

## Testing
- `npm test` *(fails: ENOENT: no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6852b636dbe08321b4ae980d497439d6