### PR TITLE
Add print preview on orçamento creation

### DIFF
--- a/pdv.blade.php
+++ b/pdv.blade.php
@@ -1949,6 +1949,15 @@
               limparVenda();
               bootstrap.Modal.getInstance(document.getElementById('modalMultiplasFormas')).hide();
               showToast('Orçamento criado com sucesso.', 'success');
+
+              const orcamentoId = res.insert_id;
+              const printUrl = '{{ url('/vendas/orcamento') }}/' + orcamentoId + '/imprimir_orcamento';
+              const printWindow = window.open(printUrl, '_blank');
+              if (printWindow) {
+                printWindow.addEventListener('load', function() {
+                  printWindow.print();
+                });
+              }
             })
             .catch(err => {
               showToast(err || 'Erro ao criar orçamento.', 'danger');


### PR DESCRIPTION
## Summary
- trigger browser print preview after successfully creating an orçamento in `pdv.blade.php`

## Testing
- `php -l pdv.blade.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68530744777c83219e4824ad97317a94