### PR TITLE
Open orçamento print in new tab

### DIFF
--- a/pdv.blade.php
+++ b/pdv.blade.php
@@ -1967,8 +1967,7 @@
               limparVenda();
               bootstrap.Modal.getInstance(document.getElementById('modalMultiplasFormas')).hide();
               const printUrl = '{{ url('/vendas/orcamento') }}/' + res.insert_id + '/print';
-              document.getElementById('printPreviewFrame').src = printUrl;
-              bootstrap.Modal.getOrCreateInstance(document.getElementById('modalPrintPreview')).show();
+              window.open(printUrl, '_blank');
               showToast('Orçamento criado com sucesso.', 'success');
             })
             .catch(err => {


### PR DESCRIPTION
## Summary
- open orçamento print page in a new browser tab

## Testing
- `php -l pdv.blade.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685320764a008321ae01b434b49f6103