### PR TITLE
Fix closing modals after note confirm

### DIFF
--- a/pdv.blade.php
+++ b/pdv.blade.php
@@ -2236,6 +2236,9 @@
                   showToast(msg, 'success');
                   const modalNFeEl = document.getElementById('modalConfirmarNFe');
                   bootstrap.Modal.getInstance(modalNFeEl).hide();
+                  const modalFinalEl = document.getElementById("modalMultiplasFormas");
+                  const modalFinal = bootstrap.Modal.getInstance(modalFinalEl);
+                  if (modalFinal) modalFinal.hide();
                 } catch (err) {
                   console.error('DEBUG emitirNotaFiscal erro:', err);
                   showToast(err || 'Erro ao emitir nota.', 'danger');
@@ -2272,6 +2275,9 @@
                   showToast(msg, 'success');
                   const modalNFeEl = document.getElementById('modalConfirmarNFe');
                   bootstrap.Modal.getInstance(modalNFeEl).hide();
+                  const modalFinalEl = document.getElementById("modalMultiplasFormas");
+                  const modalFinal = bootstrap.Modal.getInstance(modalFinalEl);
+                  if (modalFinal) modalFinal.hide();
                 } catch (err) {
                   console.error('DEBUG emitirNFCe erro:', err);
                   showToast(err || 'Erro ao emitir nota.', 'danger');


### PR DESCRIPTION
## Summary
- close payment modal when confirming NF-e or NFC-e emission

## Testing
- `php -l pdv.blade.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855689180b4832188d664237fbed03a