### PR TITLE
Atualiza estoque ao finalizar venda

### DIFF
--- a/pdv.blade.php
+++ b/pdv.blade.php
@@ -1327,6 +1327,9 @@
           $(prefix + '#produtoSearchResults').empty();
           produtoIndexAtivo = 0;
           console.log('Venda reiniciada.');
+
+          // Atualiza o cache de produtos após reiniciar a venda
+          carregarProdutosCache();
         });
 
         $(prefix + '#btnCancelarOperacao').click(function() {
@@ -1984,6 +1987,9 @@
                 $('#precoLivreInput').val('0,00');
 
                 $('#produtoSearchInput').val('').focus();
+
+                // Recarrega o cache de produtos para manter o estoque atualizado
+                carregarProdutosCache();
               }
 
               limparVenda();
@@ -2147,6 +2153,9 @@
                 $('#precoLivreInput').val('0,00');
 
                 $('#produtoSearchInput').val('').focus();
+
+                // Recarrega o cache de produtos para manter o estoque atualizado
+                carregarProdutosCache();
               }
 
               const modalNFeEl = document.getElementById('modalConfirmarNFe');


### PR DESCRIPTION
## Summary
- refresh products cache after sales actions to ensure up-to-date stock

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6855b89a997083218404e58f665b05ec