### PR TITLE
Improve product search responsiveness

### DIFF
--- a/pdv.blade.php
+++ b/pdv.blade.php
@@ -720,7 +720,8 @@
         // Busca todos os produtos para uso em cache local
         function carregarProdutosCache() {
           return $.get('{{ route("pdv.search.products") }}', {
-              q: ''
+              q: '',
+              all: 1
             })
             .done(function(data) {
               window.produtosCache = data;
@@ -732,6 +733,7 @@
         }
 
         carregarProdutosCache();
+        setInterval(carregarProdutosCache, 60000);
 
         // Filtra produtos já carregados em cache
         function buscarProdutosNoCache(query) {
@@ -884,6 +886,11 @@
             dropdownInstance.hide();
             return;
           }
+
+          const locais = buscarProdutosNoCache(val).slice(0, 20);
+          preencherResultadosDropdown(locais, val);
+          dropdownInstance.show();
+
           realizarBuscaAjax(val, this);
         });
 


### PR DESCRIPTION
## Summary
- extend `searchProducts` API to accept `all` and `limit` params
- periodically refresh product cache
- preload entire product list and search locally first
- update dropdown as results arrive from server

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855ceecd7808321a6e8bbf6241903b6